### PR TITLE
Feature/lutaml_datamodel_attributes_table macro, refactoring

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -51,13 +51,17 @@ jobs:
 
       - name: Install Grpahviz Windows
         if: matrix.os == 'windows-latest'
-        run: |
-          cinst -y graphviz
+        uses: nick-invision/retry@v1
+        with:
+          polling_interval_seconds: 5
+          timeout_minutes: 5
+          max_attempts: 3
+          command: choco install --no-progress graphviz --version 2.38.0.20190211
 
-      - name: create gvpr alias
+      - name: Check dot command
         if: matrix.os == 'windows-latest'
         run: |
-          new-alias gvpr dot.exe
+          dot -?
 
       - name: Run specs
         run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in metanorma-plugin-lutaml.gemspec
 gemspec
+

--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@ Metanorma plugin that allows you to access lutaml objects from a Metanorma docum
 $ gem install metanorma-plugin-lutaml
 ----
 
-=== Usage
+=== Usage, `lutaml` macro
 
 Given `example.exp` file with the content:
 
@@ -71,6 +71,82 @@ Will produce this output:
 === my_type3
 === my_type4
 === my_type5
+-----
+
+This macro also supports `.lutaml` files.
+
+=== Usage, `lutaml_datamodel_attributes_table` macro
+
+This macro allows to quickly render datamodel attributes/values tables. Given `example.lutaml` file with the content:
+
+[source,java]
+----
+diagram MyView {
+  title "my diagram"
+
+  enum AddressClassProfile {
+    imlicistAttributeProfile: CharacterString [0..1] {
+      definition
+        this is multiline with `ascidoc`
+      end definition
+    }
+  }
+
+  class AttributeProfile {
+    +addressClassProfile: CharacterString [0..1]
+    imlicistAttributeProfile: CharacterString [0..1] {
+      definition this is attribute definition
+    }
+  }
+}
+----
+
+And the `lutaml_datamodel_attributes_table` macro:
+
+[source,adoc]
+-----
+[lutaml_datamodel_attributes_table, example.lutaml, AttributeProfile]
+-----
+
+Will produce this output:
+
+[source,adoc]
+-----
+=== AttributeProfile
+
+
+.AttributeProfile attributes
+|===
+|Name |Definition |Mandatory/ Optional/ Conditional |Max Occur |Data Type
+
+|addressClassProfile |TODO: enum 's definition |M |1 | `CharacterString`
+
+|imlicistAttributeProfile |this is attribute definition with multiply lines |M |1 | `CharacterString`
+
+|===
+-----
+
+In case of "enumeration"(AddressClassProfile) entity:
+
+[source,adoc]
+-----
+[lutaml_datamodel_attributes_table, example.lutaml, AddressClassProfile]
+-----
+
+Will produce this output:
+
+[source,adoc]
+-----
+=== AddressClassProfile
+
+
+.AddressClassProfile values
+|===
+|Name |Definition
+
+|imlicistAttributeProfile |this is multiline with `ascidoc`
+
+|===
 -----
 
 == Documentation

--- a/lib/metanorma-plugin-lutaml.rb
+++ b/lib/metanorma-plugin-lutaml.rb
@@ -1,5 +1,6 @@
 require "metanorma/plugin/lutaml/version"
 require "metanorma/plugin/lutaml/lutaml_preprocessor"
+require "metanorma/plugin/lutaml/lutaml_datamodel_attributes_table_preprocessor"
 require "metanorma/plugin/lutaml/lutaml_diagram_block"
 
 module Metanorma

--- a/lib/metanorma/plugin/lutaml/lutaml_datamodel_attributes_table_preprocessor.rb
+++ b/lib/metanorma/plugin/lutaml/lutaml_datamodel_attributes_table_preprocessor.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "liquid"
+require "asciidoctor"
+require "asciidoctor/reader"
+require "lutaml"
+require "lutaml/uml"
+require "metanorma/plugin/lutaml/utils"
+
+module Metanorma
+  module Plugin
+    module Lutaml
+      #  Macro for quick rendering of datamodel attributes/values table
+      #  @example [lutaml_datamodel_attributes_table,path/to/lutaml,EntityName]
+      class LutamlDatamodelAttributesTablePreprocessor < Asciidoctor::Extensions::Preprocessor
+        MARCO_REGEXP =
+          /\[lutaml_datamodel_attributes_table,([^,]+),?(.+)?,([^,]+),?(.+)?\]/
+        # search document for block `datamodel_attributes_table`
+        #  read include derectives that goes after that in block and transform
+        #  into yaml2text blocks
+        def process(document, reader)
+          input_lines = reader.readlines.to_enum
+          Asciidoctor::Reader.new(processed_lines(document, input_lines))
+        end
+
+        private
+
+        def lutaml_document_from_file(document, file_path)
+          ::Lutaml::Parser
+            .parse(File.new(Utils.relative_file_path(document, file_path),
+                            encoding: "UTF-8"))
+        rescue => e
+          require 'byebug'
+          byebug
+          i =10
+        end
+
+        def processed_lines(document, input_lines)
+          input_lines.each_with_object([]) do |line, result|
+            if match = line.match(MARCO_REGEXP)
+              lutaml_path = match[1]
+              entity_name = match[3]
+              result.push(*parse_marco(lutaml_path, entity_name, document))
+            else
+              result.push(line)
+            end
+          end
+        end
+
+        def parse_marco(lutaml_path, entity_name, document)
+          lutaml_document = lutaml_document_from_file(document, lutaml_path)
+                              .serialized_document
+          entities = [lutaml_document['classes'], lutaml_document['enums']]
+                      .compact
+                      .flatten
+          entity_definition = entities.find do |klass|
+            klass['name'] == entity_name.strip
+          end
+          model_representation(entity_definition, document)
+        end
+
+        def model_representation(entity_definition, document)
+          render_result, errors = Utils.render_liquid_string(
+            template_string: table_template,
+            context_items: entity_definition,
+            context_name: 'definition'
+          )
+          Utils.notify_render_errors(document, errors)
+          render_result.split("\n")
+        end
+
+        def table_template
+          <<~TEMPLATE
+          === {{ definition.name }}
+          {{ definition.definition }}
+
+          {% if definition.attributes %}
+          {% if definition.keyword == 'enumeration' %}
+          .{{ definition.name }} values
+          |===
+          |Name |Definition
+
+          {% for item in definition.attributes %}
+          |{{ item.name }} |{{ item.definition }}
+          {% endfor %}
+          |===
+          {% else %}
+          .{{ definition.name }} attributes
+          |===
+          |Name |Definition |Mandatory/ Optional/ Conditional |Max Occur |Data Type
+
+          {% for item in definition.attributes %}
+          |{{ item.name }} |{% if item.definition %}{{ item.definition }}{% else %}TODO: enum {{ key }}'s definition{% endif %} |{% if item.cardinality.min == 0 %}O{% else %}M{% endif %} |{% if item.cardinality.max == "*" %}N{% else %}1{% endif %} |{% if item.origin %}<<{{ item.origin }}>>{% endif %} `{{ item.type }}`
+          {% endfor %}
+          |===
+          {% endif %}
+          {% endif %}
+
+          TEMPLATE
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/plugin/lutaml/lutaml_preprocessor.rb
+++ b/lib/metanorma/plugin/lutaml/lutaml_preprocessor.rb
@@ -73,31 +73,13 @@ module Metanorma
                                 context_items:,
                                 context_name:,
                                 document:)
-          render_result, errors = render_liquid_string(
+          render_result, errors = Utils.render_liquid_string(
             template_string: context_lines.join("\n"),
             context_items: context_items,
             context_name: context_name
           )
-          notify_render_errors(document, errors)
+          Utils.notify_render_errors(document, errors)
           render_result.split("\n")
-        end
-
-        def render_liquid_string(template_string:, context_items:,
-                                 context_name:)
-          liquid_template = Liquid::Template.parse(template_string)
-          rendered_string = liquid_template
-            .render(context_name => context_items,
-                    strict_variables: true,
-                    error_mode: :warn)
-          [rendered_string, liquid_template.errors]
-        end
-
-        def notify_render_errors(document, errors)
-          errors.each do |error_obj|
-            document
-              .logger
-              .warn("Liquid render error: #{error_obj.message}")
-          end
         end
       end
     end

--- a/lib/metanorma/plugin/lutaml/utils.rb
+++ b/lib/metanorma/plugin/lutaml/utils.rb
@@ -13,6 +13,24 @@ module Metanorma
             .path_resolver
             .system_path(file_path, docfile_directory)
         end
+
+        def render_liquid_string(template_string:, context_items:,
+                                 context_name:)
+          liquid_template = Liquid::Template.parse(template_string)
+          rendered_string = liquid_template
+            .render(context_name => context_items,
+                    strict_variables: true,
+                    error_mode: :warn)
+          [rendered_string, liquid_template.errors]
+        end
+
+        def notify_render_errors(document, errors)
+          errors.each do |error_obj|
+            document
+              .logger
+              .warn("Liquid render error: #{error_obj.message}")
+          end
+        end
       end
     end
   end

--- a/spec/fixtures/diagram_definitions.lutaml
+++ b/spec/fixtures/diagram_definitions.lutaml
@@ -1,0 +1,22 @@
+diagram MyView {
+  title "my diagram"
+
+  enum AddressClassProfile {
+    imlicistAttributeProfile: CharacterString [0..1] {
+      definition
+        this is multiline with `ascidoc`
+        comments
+        and list
+      end definition
+    }
+  }
+
+  class AttributeProfile {
+    +addressClassProfile: CharacterString [0..1]
+    imlicistAttributeProfile: CharacterString [0..1] {
+      definition this is attribute definition
+      with multiply lines
+      end definition
+    }
+  }
+}

--- a/spec/metanorma/plugin/lutaml/lutaml_datamodel_attributes_table_preprocessor_spec.rb
+++ b/spec/metanorma/plugin/lutaml/lutaml_datamodel_attributes_table_preprocessor_spec.rb
@@ -1,0 +1,125 @@
+require "spec_helper"
+
+RSpec.describe Metanorma::Plugin::Lutaml::LutamlPreprocessor do
+  describe "#process" do
+    let(:example_file) { fixtures_path("diagram_definitions.lutaml") }
+
+    context "when class passed as entity" do
+      let(:input) do
+        <<~TEXT
+          = Document title
+          Author
+          :docfile: test.adoc
+          :nodoc:
+          :novalid:
+          :no-isobib:
+          :imagesdir: spec/assets
+
+          [lutaml_datamodel_attributes_table,#{example_file},AttributeProfile]
+
+        TEXT
+      end
+      let(:output) do
+        <<~TEXT
+          #{BLANK_HDR}
+          <sections>
+          <clause id="_" inline-header="false" obligation="normative">
+          <title>AttributeProfile</title>
+          <table id="_">
+          <name>AttributeProfile attributes</name>
+          <thead>
+          <tr>
+          <th valign="top" align="left">Name</th>
+          <th valign="top" align="left">Definition</th>
+          <th valign="top" align="left">Mandatory/ Optional/ Conditional</th>
+          <th valign="top" align="left">Max Occur</th>
+          <th valign="top" align="left">Data Type</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+          <td valign="top" align="left">addressClassProfile</td>
+          <td valign="top" align="left">TODO: enum ‘s definition</td>
+          <td valign="top" align="left">M</td>
+          <td valign="top" align="left">1</td>
+          <td valign="top" align="left">
+          <tt>CharacterString</tt>
+          </td>
+          </tr>
+          <tr>
+          <td valign="top" align="left">imlicistAttributeProfile</td>
+          <td valign="top" align="left">this is attribute definition
+                with multiply lines</td>
+          <td valign="top" align="left">M</td>
+          <td valign="top" align="left">1</td>
+          <td valign="top" align="left">
+          <tt>CharacterString</tt>
+          </td>
+          </tr>
+          </tbody>
+          </table>
+          </clause>
+          </sections>
+          </standard-document>
+          </body></html>
+        TEXT
+      end
+
+      it "correctly renders input" do
+        expect(xml_string_conent(metanorma_process(input)))
+          .to(be_equivalent_to(output))
+      end
+    end
+
+    context "when enumeration name passed as entity" do
+      let(:input) do
+        <<~TEXT
+          = Document title
+          Author
+          :docfile: test.adoc
+          :nodoc:
+          :novalid:
+          :no-isobib:
+          :imagesdir: spec/assets
+
+          [lutaml_datamodel_attributes_table,#{example_file},AddressClassProfile]
+
+        TEXT
+      end
+      let(:output) do
+        <<~TEXT
+          #{BLANK_HDR}
+          <sections>
+          <clause id="_" inline-header="false" obligation="normative">
+          <title>AddressClassProfile</title>
+          <table id="_">
+          <name>AddressClassProfile values</name>
+          <thead>
+          <tr>
+          <th valign="top" align="left">Name</th>
+          <th valign="top" align="left">Definition</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+          <td valign="top" align="left">imlicistAttributeProfile</td>
+          <td valign="top" align="left">this is multiline with <tt>ascidoc</tt>
+                  comments
+                  and list</td>
+          </tr>
+          </tbody>
+          </table>
+          </clause>
+          </sections>
+          </standard-document>
+          </body></html>
+        TEXT
+      end
+
+      it "correctly renders input" do
+        expect(xml_string_conent(metanorma_process(input)))
+          .to(be_equivalent_to(output))
+      end
+    end
+  end
+end

--- a/spec/metanorma/plugin/lutaml/lutaml_diagram_block_spec.rb
+++ b/spec/metanorma/plugin/lutaml/lutaml_diagram_block_spec.rb
@@ -14,37 +14,14 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlDiagramBlock do
           :imagesdir: spec/assets
 
           [lutaml_diagram]
-          ----
+          ....
           diagram MyView {
+            fontname "Arial"
             title "my diagram"
-
-            class AddressClassProfile {
-              addressClassProfile
-            }
-            class AttributeProfile {
-              attributeProfile
-            }
-
-            association BidirectionalAsscoiation {
-              owner_type aggregation
-              member_type direct
-              owner AddressClassProfile#addressClassProfile
-              member AttributeProfile#attributeProfile [0..*]
-            }
-
-            association DirectAsscoiation {
-              member_type direct
-              owner AddressClassProfile
-              member AttributeProfile#attributeProfile
-            }
-
-            association ReverseAsscoiation {
-              owner_type aggregation
-              owner AddressClassProfile#addressClassProfile
-              member AttributeProfile
-            }
+            caption "my diagram"
+            class Foo {}
           }
-          ----
+          ....
         TEXT
       end
       let(:output) do
@@ -52,6 +29,7 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlDiagramBlock do
           #{BLANK_HDR}
           <sections>
           <figure id="_">
+          <name>my diagram</name>
           <image src="_" id="_" mimetype="image/png" height="auto" width="auto"></image>
           </figure>
           </sections>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require "metanorma-plugin-lutaml"
 # to test properly with metanorma-standoc
 Asciidoctor::Extensions.register do
   preprocessor Metanorma::Plugin::Lutaml::LutamlPreprocessor
+  preprocessor Metanorma::Plugin::Lutaml::LutamlDatamodelAttributesTablePreprocessor
   block Metanorma::Plugin::Lutaml::LutamlDiagramBlock, :lutaml_diagram
 end
 


### PR DESCRIPTION
New macro: `lutaml_datamodel_attributes_table` - quickly render datamodel attributes table. Refactoring.