### PR TITLE
(Hotfix) Multiply schema files relative path

### DIFF
--- a/lib/metanorma/plugin/lutaml/express_remarks_decorator.rb
+++ b/lib/metanorma/plugin/lutaml/express_remarks_decorator.rb
@@ -45,7 +45,11 @@ module Metanorma
         def prefix_relative_paths(line, path_prefix)
           line.gsub(RELATIVE_PREFIX_MACRO_REGEXP) do |_match|
             prefixed_path = File.join(path_prefix, $3.strip)
-            "#{$1}#{$2}#{prefixed_path}#{$4}"
+            # When we are dealing with arelative path of a template: ../path/to/file we need to transform it into
+            # the absolute one because `image::` macro wont understand it other way
+            prefixed_path = File.absolute_path(prefixed_path) if prefixed_path.start_with?('../')
+            full_path = File.expand_path(prefixed_path)
+            "#{$1}#{$2}#{full_path}#{$4}"
           end
         end
 

--- a/lib/metanorma/plugin/lutaml/lutaml_preprocessor.rb
+++ b/lib/metanorma/plugin/lutaml/lutaml_preprocessor.rb
@@ -78,7 +78,7 @@ module Metanorma
             else
               res.push(content_from_file(document, path)
                         .to_liquid
-                        .merge('relative_path_prefix' => File.dirname(path)))
+                        .merge('relative_path_prefix' => Utils.relative_file_path(document, File.dirname(path))))
             end
           end
         end

--- a/lib/metanorma/plugin/lutaml/lutaml_preprocessor.rb
+++ b/lib/metanorma/plugin/lutaml/lutaml_preprocessor.rb
@@ -76,19 +76,21 @@ module Metanorma
             if express_indexes[path]
               res.push(*express_indexes[path])
             else
-              res.push(content_from_file(document, path).to_liquid)
+              res.push(content_from_file(document, path)
+                        .to_liquid
+                        .merge('relative_path_prefix' => File.dirname(path)))
             end
           end
         end
 
         def parse_template(document, current_block, block_match, express_indexes)
           options = parse_options(block_match[3])
-                      .merge("relative_path_prefix" => File.dirname(block_match[1]))
           contexts_items(block_match, document, express_indexes)
             .map do |context_items|
               parse_context_block(document: document,
                                   context_lines: current_block,
-                                  context_items: decorate_context_items(context_items, options),
+                                  context_items: decorate_context_items(context_items,
+                                                    options.merge('relative_path_prefix' => context_items['relative_path_prefix'])),
                                   context_name: block_match[2].strip)
             end.flatten
         rescue StandardError => e

--- a/lib/metanorma/plugin/lutaml/utils.rb
+++ b/lib/metanorma/plugin/lutaml/utils.rb
@@ -40,6 +40,7 @@ module Metanorma
             begin
               idxs[name]
                 .push(::Lutaml::Parser.parse(File.new(path, encoding: "UTF-8")).to_liquid)
+                .merge("relative_path_prefix" => folder)
             rescue StandardError => e
               document.logger.warn("Failed to load #{path}: #{e.message}")
             end

--- a/spec/fixtures/expressir_index_1/arm_svgmap.exp
+++ b/spec/fixtures/expressir_index_1/arm_svgmap.exp
@@ -1,0 +1,36 @@
+(*"Activity_method_assignment_arm"
+Mine text
+
+[.svgmap]
+====
+image::measure_schemaexpg5.svg[]
+
+* <<express:measure_schema,measure_schema>>; ../../resources/measure_schema/measure_schema.xml
+* <<express:measure_schemaexpg4,measure_schemaexpg4>>; ./measure_schemaexpg4.xml
+* <<express:measure_schema,measure_schema>>; ../../resources/measure_schema/measure_schema.xml
+====
+
+*)
+
+SCHEMA Activity_method_assignment_arm;
+
+USE FROM Activity_method_arm;    -- ISO/TS 10303-1049
+
+
+TYPE activity_method_item = EXTENSIBLE GENERIC_ENTITY SELECT;
+END_TYPE;
+
+ENTITY Activity_method_relationship;
+  name : STRING;
+  description : OPTIONAL STRING;
+  relating_method : Activity_method;
+  related_method : Activity_method;
+END_ENTITY;
+
+ENTITY Applied_activity_method_assignment;
+  assigned_activity_method : Activity_method;
+  items : SET[1:?] OF activity_method_item;
+  role : STRING;
+END_ENTITY;
+
+END_SCHEMA;  -- Activity_method_assignment_arm

--- a/spec/metanorma/plugin/lutaml/lutaml2_text_preprocessor_spec.rb
+++ b/spec/metanorma/plugin/lutaml/lutaml2_text_preprocessor_spec.rb
@@ -326,6 +326,9 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlPreprocessor do
           #{BLANK_HDR}
           <sections>
             <clause id="_" inline-header="false" obligation="normative">
+              <title>Activity_method_assignment_arm</title>
+            </clause>
+            <clause id="_" inline-header="false" obligation="normative">
               <title>Activity_method_assignment_mim</title>
             </clause>
             <clause id="_" inline-header="false" obligation="normative">
@@ -352,8 +355,8 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlPreprocessor do
     context "when multiply files supplied to macro" do
       let(:express_files_list) do
         [
-          fixtures_path("test.exp"),
-          fixtures_path("expressir_index_1/arm.exp"),
+          fixtures_path("test_relative_includes_svgmap.exp"),
+          fixtures_path("expressir_index_1/arm_svgmap.exp"),
           fixtures_path("expressir_index_2/mim.exp"),
         ]
       end
@@ -371,6 +374,15 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlPreprocessor do
           ----
           {% for schema in my_context.schemas %}
           == {{schema.id}}
+
+          {% for schema in my_context.schemas %}
+          == {{schema.id}}
+
+          {% for remark in schema.remarks %}
+          {{ remark }}
+          {% endfor %}
+          {% endfor %}
+
           {% endfor %}
           ----
         TEXT
@@ -378,19 +390,80 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlPreprocessor do
       let(:output) do
         <<~TEXT
           #{BLANK_HDR}
-            <sections>
-              <clause id="_" inline-header="false" obligation="normative">
-                <title>annotated_3d_model_data_quality_criteria_schema</title>
-              </clause>
-              <clause id="_" inline-header="false" obligation="normative">
-                <title>Activity_method_assignment_arm</title>
-              </clause>
-              <clause id="_" inline-header="false" obligation="normative">
-                <title>Activity_method_characterized_mim</title>
-              </clause>
-            </sections>
+          <sections>
+            <clause id="_" inline-header="false" obligation="normative">
+              <title>annotated_3d_model_data_quality_criteria_schema</title>
+            </clause>
+            <clause id="_" inline-header="false" obligation="normative">
+              <title>annotated_3d_model_data_quality_criteria_schema</title>
+              <p id="_">Mine text</p>
+              <svgmap id="_">
+                <figure id="_">
+                  <image
+                    src="/Users/mitaraskin/Work/Personal/Metanorma/metanorma-plugin-lutaml/spec/fixtures/measure_schemaexpg5.svg"
+                    id="_" mimetype="image/svg+xml" height="auto" width="auto"></image>
+                </figure>
+                <target
+                  href="/Users/mitaraskin/Work/Personal/Metanorma/metanorma-plugin-lutaml/spec/fixtures/../../resources/measure_schema/measure_schema.xml">
+                  <eref bibitemid="express_measure_schema" citeas="">measure_schema</eref>
+                </target>
+                <target
+                  href="/Users/mitaraskin/Work/Personal/Metanorma/metanorma-plugin-lutaml/spec/fixtures/./measure_schemaexpg4.xml">
+                  <eref bibitemid="express_measure_schemaexpg4" citeas="">measure_schemaexpg4</eref>
+                </target>
+                <target
+                  href="/Users/mitaraskin/Work/Personal/Metanorma/metanorma-plugin-lutaml/spec/fixtures/../../resources/measure_schema/measure_schema.xml">
+                  <eref bibitemid="express_measure_schema" citeas="">measure_schema</eref>
+                </target>
+              </svgmap>
+            </clause>
+            <clause id="_" inline-header="false" obligation="normative">
+              <title>Activity_method_assignment_arm</title>
+            </clause>
+            <clause id="_" inline-header="false" obligation="normative">
+              <title>Activity_method_assignment_arm</title>
+              <p id="_">Mine text</p>
+              <svgmap id="_">
+                <figure id="_">
+                  <image
+                    src="/Users/mitaraskin/Work/Personal/Metanorma/metanorma-plugin-lutaml/spec/fixtures/expressir_index_1/measure_schemaexpg5.svg"
+                    id="_" mimetype="image/svg+xml" height="auto" width="auto"></image>
+                </figure>
+                <target
+                  href="/Users/mitaraskin/Work/Personal/Metanorma/metanorma-plugin-lutaml/spec/fixtures/expressir_index_1/../../resources/measure_schema/measure_schema.xml">
+                  <eref bibitemid="express_measure_schema" citeas="">measure_schema</eref>
+                </target>
+                <target
+                  href="/Users/mitaraskin/Work/Personal/Metanorma/metanorma-plugin-lutaml/spec/fixtures/expressir_index_1/./measure_schemaexpg4.xml">
+                  <eref bibitemid="express_measure_schemaexpg4" citeas="">measure_schemaexpg4</eref>
+                </target>
+                <target
+                  href="/Users/mitaraskin/Work/Personal/Metanorma/metanorma-plugin-lutaml/spec/fixtures/expressir_index_1/../../resources/measure_schema/measure_schema.xml">
+                  <eref bibitemid="express_measure_schema" citeas="">measure_schema</eref>
+                </target>
+              </svgmap>
+            </clause>
+            <clause id="_" inline-header="false" obligation="normative">
+              <title>Activity_method_characterized_mim</title>
+            </clause>
+            <clause id="_" inline-header="false" obligation="normative">
+              <title>Activity_method_characterized_mim</title>
+            </clause>
+          </sections>
+          <bibliography>
+            <references hidden="true" normative="false">
+              <bibitem id="express_measure_schema" type="internal">
+                <docidentifier type="repository">express/measure_schema</docidentifier>
+              </bibitem>
+              <bibitem id="express_measure_schemaexpg4" type="internal">
+                <docidentifier type="repository">express/measure_schemaexpg4</docidentifier>
+              </bibitem>
+            </references>
+          </bibliography>
           </standard-document>
-          </body></html>
+          </body>
+
+          </html>
         TEXT
       end
 

--- a/spec/metanorma/plugin/lutaml/lutaml2_text_preprocessor_spec.rb
+++ b/spec/metanorma/plugin/lutaml/lutaml2_text_preprocessor_spec.rb
@@ -400,19 +400,19 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlPreprocessor do
               <svgmap id="_">
                 <figure id="_">
                   <image
-                    src="/Users/mitaraskin/Work/Personal/Metanorma/metanorma-plugin-lutaml/spec/fixtures/measure_schemaexpg5.svg"
+                    src="#{fixtures_path('measure_schemaexpg5.svg')}"
                     id="_" mimetype="image/svg+xml" height="auto" width="auto"></image>
                 </figure>
                 <target
-                  href="/Users/mitaraskin/Work/Personal/Metanorma/metanorma-plugin-lutaml/spec/fixtures/../../resources/measure_schema/measure_schema.xml">
+                  href="#{fixtures_path('../../resources/measure_schema/measure_schema.xml')}">
                   <eref bibitemid="express_measure_schema" citeas="">measure_schema</eref>
                 </target>
                 <target
-                  href="/Users/mitaraskin/Work/Personal/Metanorma/metanorma-plugin-lutaml/spec/fixtures/./measure_schemaexpg4.xml">
+                  href="#{fixtures_path('./measure_schemaexpg4.xml')}">
                   <eref bibitemid="express_measure_schemaexpg4" citeas="">measure_schemaexpg4</eref>
                 </target>
                 <target
-                  href="/Users/mitaraskin/Work/Personal/Metanorma/metanorma-plugin-lutaml/spec/fixtures/../../resources/measure_schema/measure_schema.xml">
+                  href="#{fixtures_path('../../resources/measure_schema/measure_schema.xml')}">
                   <eref bibitemid="express_measure_schema" citeas="">measure_schema</eref>
                 </target>
               </svgmap>
@@ -426,19 +426,19 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlPreprocessor do
               <svgmap id="_">
                 <figure id="_">
                   <image
-                    src="/Users/mitaraskin/Work/Personal/Metanorma/metanorma-plugin-lutaml/spec/fixtures/expressir_index_1/measure_schemaexpg5.svg"
+                    src="#{fixtures_path('expressir_index_1/measure_schemaexpg5.svg')}"
                     id="_" mimetype="image/svg+xml" height="auto" width="auto"></image>
                 </figure>
                 <target
-                  href="/Users/mitaraskin/Work/Personal/Metanorma/metanorma-plugin-lutaml/spec/fixtures/expressir_index_1/../../resources/measure_schema/measure_schema.xml">
+                  href="#{fixtures_path('expressir_index_1/../../resources/measure_schema/measure_schema.xml')}">
                   <eref bibitemid="express_measure_schema" citeas="">measure_schema</eref>
                 </target>
                 <target
-                  href="/Users/mitaraskin/Work/Personal/Metanorma/metanorma-plugin-lutaml/spec/fixtures/expressir_index_1/./measure_schemaexpg4.xml">
+                  href="#{fixtures_path('expressir_index_1/./measure_schemaexpg4.xml')}">
                   <eref bibitemid="express_measure_schemaexpg4" citeas="">measure_schemaexpg4</eref>
                 </target>
                 <target
-                  href="/Users/mitaraskin/Work/Personal/Metanorma/metanorma-plugin-lutaml/spec/fixtures/expressir_index_1/../../resources/measure_schema/measure_schema.xml">
+                  href="#{fixtures_path('expressir_index_1/../../resources/measure_schema/measure_schema.xml')}">
                   <eref bibitemid="express_measure_schema" citeas="">measure_schema</eref>
                 </target>
               </svgmap>

--- a/spec/metanorma/plugin/lutaml/lutaml2_text_preprocessor_spec.rb
+++ b/spec/metanorma/plugin/lutaml/lutaml2_text_preprocessor_spec.rb
@@ -192,15 +192,15 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlPreprocessor do
             <clause id="_" inline-header="false" obligation="normative"><title>annotated_3d_model_data_quality_criteria_schema</title>
             <p id="_">Mine text</p>
             <p id="_">
-            <link target="#{doc_path}/downloads/report.pdf">Get Report
+            <link target="#{fixtures_path('/downloads/report.pdf')}">Get Report
             </p>
             <p id="_">
             <link target="http://test.com/include1.csv">
             </p>
 
 
-            <p id="_">include::#{doc_path}/include1.csv[]</p>
-            <p id="_">include::#{doc_path}/test/include1.csv[]</p>
+            <p id="_">include::#{fixtures_path('/include1.csv')}[]</p>
+            <p id="_">include::#{fixtures_path('test/include1.csv')}[]</p>
             <p id="_">include::http://test.com/include1.csv[]</p>
             <figure id="_">
               <pre id="_"></pre>
@@ -252,16 +252,16 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlPreprocessor do
               <p id="_">Mine text</p>
               <svgmap id="_">
                 <figure id="_">
-                  <image src="spec/assets/spec/fixtures/measure_schemaexpg5.svg" id="_" mimetype="image/svg+xml"
+                  <image src="#{File.expand_path(fixtures_path('measure_schemaexpg5.svg'))}" id="_" mimetype="image/svg+xml"
                     height="auto" width="auto"></image>
                 </figure>
-                <target href="spec/fixtures/../../resources/measure_schema/measure_schema.xml">
+                <target href="#{File.expand_path(fixtures_path('../../resources/measure_schema/measure_schema.xml'))}">
                   <eref bibitemid="express_measure_schema" citeas="">measure_schema</eref>
                 </target>
-                <target href="spec/fixtures/./measure_schemaexpg4.xml">
+                <target href="#{File.expand_path(fixtures_path('./measure_schemaexpg4.xml'))}">
                   <eref bibitemid="express_measure_schemaexpg4" citeas="">measure_schemaexpg4</eref>
                 </target>
-                <target href="spec/fixtures/../../resources/measure_schema/measure_schema.xml">
+                <target href="#{File.expand_path(fixtures_path('../../resources/measure_schema/measure_schema.xml'))}">
                   <eref bibitemid="express_measure_schema" citeas="">measure_schema</eref>
                 </target>
               </svgmap>
@@ -282,6 +282,7 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlPreprocessor do
           </bibliography>
           </standard-document>
           </body>
+
           </html>
         TEXT
       end
@@ -400,19 +401,19 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlPreprocessor do
               <svgmap id="_">
                 <figure id="_">
                   <image
-                    src="#{fixtures_path('measure_schemaexpg5.svg')}"
+                    src="#{File.expand_path(fixtures_path('measure_schemaexpg5.svg'))}"
                     id="_" mimetype="image/svg+xml" height="auto" width="auto"></image>
                 </figure>
                 <target
-                  href="#{fixtures_path('../../resources/measure_schema/measure_schema.xml')}">
+                  href="#{File.expand_path(fixtures_path('../../resources/measure_schema/measure_schema.xml'))}">
                   <eref bibitemid="express_measure_schema" citeas="">measure_schema</eref>
                 </target>
                 <target
-                  href="#{fixtures_path('./measure_schemaexpg4.xml')}">
+                  href="#{File.expand_path(fixtures_path('./measure_schemaexpg4.xml'))}">
                   <eref bibitemid="express_measure_schemaexpg4" citeas="">measure_schemaexpg4</eref>
                 </target>
                 <target
-                  href="#{fixtures_path('../../resources/measure_schema/measure_schema.xml')}">
+                  href="#{File.expand_path(fixtures_path('../../resources/measure_schema/measure_schema.xml'))}">
                   <eref bibitemid="express_measure_schema" citeas="">measure_schema</eref>
                 </target>
               </svgmap>
@@ -426,19 +427,19 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlPreprocessor do
               <svgmap id="_">
                 <figure id="_">
                   <image
-                    src="#{fixtures_path('expressir_index_1/measure_schemaexpg5.svg')}"
+                    src="#{File.expand_path(fixtures_path('expressir_index_1/measure_schemaexpg5.svg'))}"
                     id="_" mimetype="image/svg+xml" height="auto" width="auto"></image>
                 </figure>
                 <target
-                  href="#{fixtures_path('expressir_index_1/../../resources/measure_schema/measure_schema.xml')}">
+                  href="#{File.expand_path(fixtures_path('expressir_index_1/../../resources/measure_schema/measure_schema.xml'))}">
                   <eref bibitemid="express_measure_schema" citeas="">measure_schema</eref>
                 </target>
                 <target
-                  href="#{fixtures_path('expressir_index_1/./measure_schemaexpg4.xml')}">
+                  href="#{File.expand_path(fixtures_path('expressir_index_1/./measure_schemaexpg4.xml'))}">
                   <eref bibitemid="express_measure_schemaexpg4" citeas="">measure_schemaexpg4</eref>
                 </target>
                 <target
-                  href="#{fixtures_path('expressir_index_1/../../resources/measure_schema/measure_schema.xml')}">
+                  href="#{File.expand_path(fixtures_path('expressir_index_1/../../resources/measure_schema/measure_schema.xml'))}">
                   <eref bibitemid="express_measure_schema" citeas="">measure_schema</eref>
                 </target>
               </svgmap>


### PR DESCRIPTION
Fix for the case when multiply schema files provided in lutaml macro and the relative path gets messed up with all paths