### PR TITLE
(Hotfix) Correct reader for LutamlPreprocessor, process dynamically created includes

### DIFF
--- a/lib/metanorma/plugin/lutaml/lutaml_preprocessor.rb
+++ b/lib/metanorma/plugin/lutaml/lutaml_preprocessor.rb
@@ -21,8 +21,9 @@ module Metanorma
             document,
             input_lines
           )
-          Asciidoctor::Reader
-            .new(processed_lines(document, input_lines, express_indexes))
+          result_content = processed_lines(document, input_lines, express_indexes)
+          result_reader = Asciidoctor::PreprocessorReader.new(document, result_content)
+          result_reader
         end
 
         protected

--- a/spec/fixtures/include_test.adoc
+++ b/spec/fixtures/include_test.adoc
@@ -1,0 +1,3 @@
+== Test
+
+My content

--- a/spec/metanorma/plugin/lutaml/lutaml2_text_preprocessor_spec.rb
+++ b/spec/metanorma/plugin/lutaml/lutaml2_text_preprocessor_spec.rb
@@ -193,10 +193,12 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlPreprocessor do
             </p>
 
 
-            <p id="_">include::#{fixtures_path('/include1.csv')}[]</p>
-            <p id="_">include::#{fixtures_path('test/include1.csv')}[]</p>
-            <p id="_">include::http://test.com/include1.csv[]</p>
-            </clause>
+            <p id="_">header1,header2,header3
+            one,two,three</p>
+            <p id="_">Unresolved directive in &lt;stdin&gt;&#8201;&#8212;&#8201;include::#{fixtures_path('test/include1.csv')}[]</p>
+            <p id="_">
+            <link target="http://test.com/include1.csv">
+            </p></clause>
           </sections>
           </standard-document>
           </body></html>
@@ -246,10 +248,11 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlPreprocessor do
               <p id="_">
               <link target="http://test.com/include1.csv">
               </p>
-              <p id="_">include::#{fixtures_path('/expressir_realtive_paths/include1.csv')}[]</p>
-              <p id="_">include::#{fixtures_path('expressir_realtive_paths/test/include1.csv')}[]</p>
-              <p id="_">include::http://test.com/include1.csv[]</p>
-              </clause>
+              <p id="_">Unresolved directive in &lt;stdin&gt;&#8201;&#8212;&#8201;include::#{fixtures_path('/expressir_realtive_paths/include1.csv')}[]</p>
+              <p id="_">Unresolved directive in &lt;stdin&gt;&#8201;&#8212;&#8201;include::#{fixtures_path('expressir_realtive_paths/test/include1.csv')}[]</p>
+              <p id="_">
+              <link target="http://test.com/include1.csv">
+              </p></clause>
             </sections>
             </standard-document>
             </body></html>
@@ -695,6 +698,44 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlPreprocessor do
           </standard-document>
           </body>
 
+          </html>
+        TEXT
+      end
+
+      it "correctly renders input" do
+        expect(xml_string_conent(metanorma_process(input)))
+          .to(be_equivalent_to(output))
+      end
+    end
+
+    context "when dynamic include block used" do
+      let(:input) do
+        <<~TEXT
+          = Document title
+          Author
+          :docfile: test.adoc
+          :nodoc:
+          :novalid:
+          :no-isobib:
+
+          [lutaml, #{example_file}, my_context]
+          ----
+          {% assign my_include = "include" %}
+          {{ my_include }}::#{fixtures_path("include_test.adoc")}[]
+          ----
+        TEXT
+      end
+      let(:output) do
+        <<~TEXT
+          #{BLANK_HDR}
+          <sections>
+          <clause id="_" inline-header="false" obligation="normative">
+          <title>Test</title>
+          <p id="_">My content</p>
+          </clause>
+          </sections>
+          </standard-document>
+          </body>
           </html>
         TEXT
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,11 +4,11 @@ require "metanorma-plugin-lutaml"
 
 # Register lutaml blocks as first preprocessors in line in order
 # to test properly with metanorma-standoc
-Asciidoctor::Extensions.register do
-  preprocessor Metanorma::Plugin::Lutaml::LutamlPreprocessor
-  preprocessor Metanorma::Plugin::Lutaml::LutamlUmlAttributesTablePreprocessor
-  block Metanorma::Plugin::Lutaml::LutamlDiagramBlock, :lutaml_diagram
-end
+# Asciidoctor::Extensions.register do
+#   preprocessor Metanorma::Plugin::Lutaml::LutamlPreprocessor
+#   preprocessor Metanorma::Plugin::Lutaml::LutamlUmlAttributesTablePreprocessor
+#   block Metanorma::Plugin::Lutaml::LutamlDiagramBlock, :lutaml_diagram
+# end
 
 require "metanorma-standoc"
 require "rspec/matchers"


### PR DESCRIPTION
Currently, if lutaml will create dynamic `include` macroses they won't be processed because of the reader used in  Asciidoctor::LutamlPreprocessor. Use the correct reader for `LutamlPreprocessor` in order for process dynamically created includes.