### PR TITLE
Relax ogc-gml dependency to allow 1.1.x

### DIFF
--- a/metanorma-plugin-lutaml.gemspec
+++ b/metanorma-plugin-lutaml.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "expressir", "~> 2.1"
   spec.add_dependency "isodoc"
   spec.add_dependency "liquid"
-  spec.add_dependency "lutaml", "~> 0.9"
-  spec.add_dependency "ogc-gml", "~>1.0.0"
+  spec.add_dependency "lutaml", "~> 0.10"
+  spec.add_dependency "ogc-gml", "~> 1.0"
   spec.add_dependency "relaton-cli"
 
   spec.metadata["rubygems_mfa_required"] = "false"


### PR DESCRIPTION
## Summary
- Relaxes `ogc-gml` dependency from `~> 1.0.0` to `~> 1.0` to allow ogc-gml 1.1.0
- ogc-gml 1.1.0 adds support for lutaml-model 0.8.0 which introduces breaking API changes (XmlNamespace classes, new adapter paths, etc.)

## Test plan
- [ ] Verify `bundle install` resolves ogc-gml to 1.1.0 when lutaml-model 0.8.x is present
- [ ] Verify existing tests still pass with ogc-gml 1.1.0