### PR TITLE
fix: guard update_remarks recursion against RemarkItem children

### DIFF
--- a/lib/metanorma/plugin/lutaml/lutaml_preprocessor.rb
+++ b/lib/metanorma/plugin/lutaml/lutaml_preprocessor.rb
@@ -86,14 +86,25 @@ module Metanorma
 
         def update_remarks(model, options)
           model.remarks = decorate_remarks(options, model.remarks)
-          model.remark_items&.each do |ri|
-            ri.remarks = decorate_remarks(options, ri.remarks)
-          end
+          decorate_remark_items(model, options)
 
           model.children.each do |child|
-            next unless child.is_a?(Expressir::Model::ModelElement)
+            next unless traversable_model_element?(child)
 
             update_remarks(child, options)
+          end
+        end
+
+        def traversable_model_element?(child)
+          child.is_a?(Expressir::Model::ModelElement) &&
+            !child.is_a?(Expressir::Model::Declarations::RemarkItem)
+        end
+
+        def decorate_remark_items(model, options)
+          return unless model.is_a?(Expressir::Model::HasRemarkItems)
+
+          model.remark_items&.each do |ri|
+            ri.remarks = decorate_remarks(options, ri.remarks)
           end
         end
 

--- a/spec/metanorma/plugin/lutaml/lutaml_text_preprocessor_spec.rb
+++ b/spec/metanorma/plugin/lutaml/lutaml_text_preprocessor_spec.rb
@@ -831,5 +831,40 @@ RSpec.describe Metanorma::Plugin::Lutaml::LutamlPreprocessor do
         end
       end
     end
+
+    describe "#update_remarks" do
+      let(:preprocessor) { described_class.new }
+
+      it "does not raise when a RemarkItem appears in children" do
+        schema = Expressir::Model::Declarations::Schema.new(
+          id: "test_schema",
+          remarks: [],
+        )
+        remark_item = Expressir::Model::Declarations::RemarkItem.new(
+          remarks: ["some remark"],
+        )
+        allow(schema).to receive(:children).and_return([remark_item])
+
+        expect do
+          preprocessor.send(:update_remarks, schema, {})
+        end.not_to raise_error
+      end
+
+      it "decorates remark_items on models that include HasRemarkItems" do
+        entity = Expressir::Model::Declarations::Entity.new(
+          id: "test_entity",
+          remarks: [],
+        )
+        ri = Expressir::Model::Declarations::RemarkItem.new(
+          remarks: ["original"],
+        )
+        allow(entity).to receive_messages(remark_items: [ri], children: [])
+
+        preprocessor.send(:update_remarks, entity,
+                          { "remark_format" => "prefix" })
+
+        expect(ri.remarks).not_to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

`update_remarks` recurses through `model.children`, which includes `RemarkItem` nodes. `RemarkItem` is a `ModelElement` but does NOT have `remark_items` — only the `HasRemarkItems` mixin provides that accessor. The `&.` safe navigation operator only guards against `nil`, not missing methods, so `model.remark_items&.each` raises `NoMethodError` when `model` is a `RemarkItem`.

Reported in #270 when building ISO 10303 schemas with remarks.

## Fix

- **Guard `remark_items` with `is_a?(HasRemarkItems)`** — the proper type marker from expressir that distinguishes nodes with remark_items from those without
- **Skip `RemarkItem` in the children traversal** — it is a terminal node; its remarks are already decorated by the parent
- Extracted `decorate_remark_items` and `traversable_model_element?` to keep `update_remarks` clean (avoids rubocop complexity violations)

## Testing

Added 2 focused unit tests:
- `update_remarks` does not raise when a `RemarkItem` appears in children
- `update_remarks` decorates `remark_items` on models that include `HasRemarkItems`

All 17 EXPRESS specs pass (was 15 before).

Fixes #270